### PR TITLE
fix youtube-dl comment

### DIFF
--- a/site/esoterrarium/freestuff/index.html
+++ b/site/esoterrarium/freestuff/index.html
@@ -227,7 +227,7 @@
 			<p>
 				<em class="bold">youtube-dl</em> 
 				<span class="icon-ufsc"><img src="/resources/img/icon_ufsc_open.svg" alt=""></span> 
-				&mdash; command line program for downloading videos from YouTube and a ton of other sites. Notably survived an attempted takedown from YouTube.
+				&mdash; command line program for downloading videos from YouTube and a ton of other sites. Notably survived an attempted takedown from the Recording Industry Association of America.
 				<br>
 				<a href="https://ytdl-org.github.io/youtube-dl/" target="_blank">Homepage</a>
 				<br>


### PR DESCRIPTION
"err, actually..."

Couldn't resist - the takedown was from [RIAA](https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md), not YouTube.